### PR TITLE
Added version 16 node as dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1]
-        node-version: [19.7]
+        node-version: [16, 19.7] #Adding version 16 because Amazon Linux 2 cant support higher versions of node
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1]
-        node-version: [19.7]
+        node-version: [16, 19.7] #Adding version 16 because Amazon Linux 2 cant support higher versions of node
 
     name: PHP ${{ matrix.php }}
 


### PR DESCRIPTION
Amazon Linux 2 cant support higher versions of node as their GLIBC libraries are outdated.